### PR TITLE
change data type decimal to float in product and discount table

### DIFF
--- a/db/migrate/20240523072249_change_price_column_type_in_products.rb
+++ b/db/migrate/20240523072249_change_price_column_type_in_products.rb
@@ -1,0 +1,5 @@
+class ChangePriceColumnTypeInProducts < ActiveRecord::Migration[7.1]
+  def change
+     change_column :products, :price, :float,  precision: 10, scale: 2
+  end
+end

--- a/db/migrate/20240523072617_change_discount_percentage_column_type_in_promotions.rb
+++ b/db/migrate/20240523072617_change_discount_percentage_column_type_in_promotions.rb
@@ -1,0 +1,5 @@
+class ChangeDiscountPercentageColumnTypeInPromotions < ActiveRecord::Migration[7.1]
+  def change
+     change_column :promotions, :discount_percentage, :float, precision: 10, scale: 2
+  end
+end


### PR DESCRIPTION
what: change the datatype decimal to float
why: storing the correct price into the database